### PR TITLE
RoofRunning CSS improvements

### DIFF
--- a/RoofRunning/RoofRunning.css
+++ b/RoofRunning/RoofRunning.css
@@ -3,6 +3,16 @@
   --grid-rows: 8;
   --temp-grid-columns: 11;
   --temp-grid-rows: 8;
+
+  /*
+  If everything was symmetrical, we could use vmin units for the grid blocks.
+  However, there's other items on screen and the number of columns/rows can change.
+  So instead, let's calculate a custom unit to use instead.
+  */
+  --vw-block-size: calc(85vw / var(--grid-columns));
+  --vh-block-size: calc(70vh / var(--grid-rows));
+  --block-size: min(var(--vw-block-size), var(--vh-block-size));
+  --block-unit: calc(var(--block-size) / 7.5);  /* This should be approx 1vmin */
 }
 
 @font-face {
@@ -23,15 +33,15 @@ body {
 
 .hack-box-container {
   position: relative;
-  border-radius: 10px;
-  outline: 1px solid gray;
+  border-radius: 0.5rem;
+  outline: 0.1rem solid gray;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  margin: 0 auto;
-  width: calc(var(--grid-columns) * (90px + 2px) + 20px);
-  height: calc(var(--grid-rows) * (90px + 5px + 2px) + 90px);
+  margin: 2.5vh auto;
+  width: fit-content;
+  overflow: hidden;
 }
 
 .info-container {
@@ -43,13 +53,13 @@ body {
 }
 
 .info-container h2 {
-  font-size: 25px;
+  font-size: 1.5rem;
   color: rgb(84, 255, 164);
   text-shadow: 0 0 2.1px rgb(127, 255, 191);
 }
 
 .info-container p {
-  font-size: 15px;
+  font-size: 1rem;
   color: rgb(142, 142, 142);
 }
 
@@ -60,38 +70,31 @@ body {
   justify-content: center;
   width: 100%;
   height: 100%;
-  background-color: rgb(15, 27, 33);
+  background-color: rgb(7, 19, 32);
 }
 
 .hack-box {
-  border-radius: 5px;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  width: calc(var(--grid-columns) * (90px + 2px));
-  height: calc(var(--grid-rows) * (90px + 5px + 2px));
-  background-color: rgb(22, 40, 52);
   display: flex;
+  margin: 0 .75rem 1rem 0.75rem;
 }
 
 .lock-container {
   display: grid;
   grid-template-columns: repeat(var(--grid-columns), 1fr);
   grid-template-rows: repeat(var(--grid-rows), 1fr);
-  width: calc(var(--grid-columns) * (90px + 2px));
-  height: calc(var(--grid-rows) * (90px + 5px + 2px));
+  gap: calc(var(--block-unit) * 0.5) calc(var(--block-unit) * 0.25);
   z-index: 999;
 }
 
 .timer-container {
-    background-color: rgb(15, 27, 33);
+    background-color: rgb(36, 47, 59);
     display: flex;
     width: 100%;
     height: 10px;
     margin-top: auto;
-    overflow: hidden;
-    border-bottom-left-radius: 10px;
-    border-bottom-right-radius: 10px;
   }
   
 
@@ -158,20 +161,21 @@ body {
 }
 
 .cube {
-  width: 90px;
-  height: 90px;
-  border: 1.5px solid #fff;  
+  /*box-sizing: border-box;*/
+  width: var(--block-size);
+  height: var(--block-size);
+  border: calc(var(--block-unit) * 0.15) solid rgba(255,255,255, 0.4);
   background:
-  linear-gradient(to right, rgba(255, 255, 255, 0.74) 1px, transparent 1px) 2px 2px,
-  linear-gradient(to right, rgba(255, 255, 255, 0.74) 1px, transparent 1px) 2px calc(100% - 2px),
-  linear-gradient(to left, rgba(255, 255, 255, 0.74) 1px, transparent 1px) calc(100% - 2px) 2px,
-  linear-gradient(to left, rgba(255, 255, 255, 0.74) 1px, transparent 1px) calc(100% - 2px) calc(100% - 2px),
-  linear-gradient(to bottom, rgba(255, 255, 255, 0.74) 1px, transparent 1px) 2px 2px,
-  linear-gradient(to bottom, rgba(255, 255, 255, 0.74) 1px, transparent 1px) calc(100% - 2px) 2px,
-  linear-gradient(to top, rgba(255, 255, 255, 0.74) 1px, transparent 1px) 2px calc(100% - 2px),
-  linear-gradient(to top, rgba(255, 255, 255, 0.74) 1px, transparent 1px) calc(100% - 2px) calc(100% - 2px);
+  linear-gradient(to right, rgba(255, 255, 255, 0.5) calc(var(--block-unit) * 0.1), transparent calc(var(--block-unit) * 0.1)) calc(var(--block-unit) * 0.3) calc(var(--block-unit) * 0.3),
+  linear-gradient(to right, rgba(255, 255, 255, 0.5) calc(var(--block-unit) * 0.1), transparent calc(var(--block-unit) * 0.1)) calc(var(--block-unit) * 0.3) calc(100% - calc(var(--block-unit) * 0.3)),
+  linear-gradient(to left, rgba(255, 255, 255, 0.5) calc(var(--block-unit) * 0.1), transparent calc(var(--block-unit) * 0.1)) calc(100% - calc(var(--block-unit) * 0.3)) calc(var(--block-unit) * 0.3),
+  linear-gradient(to left, rgba(255, 255, 255, 0.5) calc(var(--block-unit) * 0.1), transparent calc(var(--block-unit) * 0.1)) calc(100% - calc(var(--block-unit) * 0.3)) calc(100% - calc(var(--block-unit) * 0.3)),
+  linear-gradient(to bottom, rgba(255, 255, 255, 0.5) calc(var(--block-unit) * 0.1), transparent calc(var(--block-unit) * 0.1)) calc(var(--block-unit) * 0.3) calc(var(--block-unit) * 0.3),
+  linear-gradient(to bottom, rgba(255, 255, 255, 0.5) calc(var(--block-unit) * 0.1), transparent calc(var(--block-unit) * 0.1)) calc(100% - calc(var(--block-unit) * 0.3)) calc(var(--block-unit) * 0.3),
+  linear-gradient(to top, rgba(255, 255, 255, 0.5) calc(var(--block-unit) * 0.1), transparent calc(var(--block-unit) * 0.1)) calc(var(--block-unit) * 0.3) calc(100% - calc(var(--block-unit) * 0.3)),
+  linear-gradient(to top, rgba(255, 255, 255, 0.5) calc(var(--block-unit) * 0.1), transparent calc(var(--block-unit) * 0.1)) calc(100% - calc(var(--block-unit) * 0.3)) calc(100% - calc(var(--block-unit) * 0.3));
   background-repeat: no-repeat;
-  background-size: 22px 22px;
+  background-size: calc(var(--block-unit) * 1.8) calc(var(--block-unit) * 1.8);
   z-index: 1000;
 }
 
@@ -197,6 +201,7 @@ body {
 
 .cubeg {
   background-color: var(--cube-color-green, rgb(137, 218, 61));
+  /*background: linear-gradient(to bottom, rgb(155, 187, 105), rgb(128, 153, 54));*/
   box-shadow: 0px 5px 0px var(--cube-color-green-shadow, rgb(79, 122, 59));
 }
 


### PR DESCRIPTION
Multiple CSS improvements to roof running:
- Now fully responsive, it resizes based on the screen size. Theoretically should also work on mobile
- Some color/spacing changes to better reflect the NoPixel version.

I was going to include a color update because the NoPixel version has a gradient background. However, since the CSS cube class defines background-size, the background-color can't be set. It would probably require a second element, which would be a bit more complicated. If the roofrunning puzzle is rewritten to remove DOM reliance as discussed in #25, it could probably be done after that.