### PR TITLE
Minor CSS patch for short screens

### DIFF
--- a/RoofRunning/RoofRunning.css
+++ b/RoofRunning/RoofRunning.css
@@ -10,7 +10,7 @@
   So instead, let's calculate a custom unit to use instead.
   */
   --vw-block-size: calc(85vw / var(--grid-columns));
-  --vh-block-size: calc(70vh / var(--grid-rows));
+  --vh-block-size: calc(calc(calc(100vh - 150px) * 0.8) / var(--grid-rows));
   --block-size: min(var(--vw-block-size), var(--vh-block-size));
   --block-unit: calc(var(--block-size) / 7.5);  /* This should be approx 1vmin */
 }


### PR DESCRIPTION
Re: https://github.com/MaximilianAdF/NoPixel-MiniGames-4.0/pull/32#issuecomment-1953933561

The changes made in #32 didn't work very well on screens <670px. Screens of this height are quite rare but nonetheless this PR patches the bug. Instead of using `70vh`, it uses `(100vh - 150px) * 0.8`(80vh minus 150px)