### PR TITLE
Roof Running Color Improvements 

### DIFF
--- a/RoofRunning/RoofRunning.css
+++ b/RoofRunning/RoofRunning.css
@@ -195,19 +195,18 @@ body {
 }
 
 .cuber {
-  background-color: var(--cube-color-red, rgb(229, 28, 28));
-  box-shadow: 0px 5px 0px var(--cube-color-red-shadow, rgb(96, 35, 34));
+  background: linear-gradient(to bottom, #f30308, #92383b);
+  box-shadow: 0px 5px 0px #5c2829;
 }
 
 .cubeg {
-  background-color: var(--cube-color-green, rgb(137, 218, 61));
-  /*background: linear-gradient(to bottom, rgb(155, 187, 105), rgb(128, 153, 54));*/
-  box-shadow: 0px 5px 0px var(--cube-color-green-shadow, rgb(79, 122, 59));
+  background: linear-gradient(to bottom, #8ab357, #668a3d);
+  box-shadow: 0px 5px 0px #48612f;
 }
 
 .cubeb {
-  background-color: var(--cube-color-blue, rgb(82, 156, 209));
-  box-shadow: 0px 5px 0px var(--cube-color-blue-shadow, rgb(40, 71, 86));
+  background: linear-gradient(to bottom, #5490b2, #3a7494);
+  box-shadow: 0px 5px 0px #345066;
 }
 
 .other-container {

--- a/RoofRunning/RoofRunning.js
+++ b/RoofRunning/RoofRunning.js
@@ -14,14 +14,17 @@ var Cube = /** @class */ (function () {
     }
     Cube.prototype.getElement = function () {
         var element = document.createElement("div");
-        element.className = "cube";
+        var child = document.createElement("div");
+        child.className = "cube";
         if (this.color !== "empty") {
-            element.classList.add("cube" + this.color.substring(0, 1));
+            element.className = "cube" + this.color.substring(0, 1);
             element.addEventListener("click", this.squareClick.bind(this));
         }
         else {
-            element.classList.add("empty");
+            element.className = "empty";
+            child.classList.add("empty");
         }
+        element.appendChild(child);
         return element;
     };
     Cube.prototype.cubeLeftShift = function () {

--- a/RoofRunning/RoofRunning.ts
+++ b/RoofRunning/RoofRunning.ts
@@ -18,13 +18,17 @@ class Cube {
 
     getElement() {
         const element = document.createElement("div");
-        element.className = "cube";
+        const child = document.createElement("div");
+
+        child.className = "cube";
         if (this.color !== "empty") {
-            element.classList.add("cube" + this.color.substring(0,1));
+            element.className = "cube" + this.color.substring(0,1);
             element.addEventListener("click", this.squareClick.bind(this));
         } else {
-            element.classList.add("empty");
+            element.className = "empty";
+            child.classList.add("empty");
         }
+        element.appendChild(child)
         return element;
     }
     

--- a/RoofRunning/RoofRunning.ts
+++ b/RoofRunning/RoofRunning.ts
@@ -4,7 +4,7 @@ let totalSeconds = 25;
 let gridCols = 11;
 let gridRows = 8;
 
-let container: Array<Cube>;
+let container: Cube[];
 let htmlContainer: HTMLElement;
 
 class Cube {
@@ -84,7 +84,7 @@ class Cube {
         });
     }
 
-    getAdjacentCubes(cube) {
+    getAdjacentCubes(cube: Cube) {
         const idx = Array.from(container).indexOf(cube);
         // const idx = container.indexOf(cube);
         const adjacentCubes: Cube[] = [];
@@ -156,14 +156,14 @@ class Cube {
 }
 
 //The functions below together checks solvability of the board
-function helpFunct(tempContainer, queue, path = []): boolean {
+function helpFunct(tempContainer: Cube[], queue: Set<Cube>[], path = []): boolean {
     if (getColorCount(tempContainer).includes(1)) {
         console.log("FAIL, SINGLE:", path)
         return false;
     }
 
     let c = 0;
-    tempContainer.forEach(cube => {
+    tempContainer.forEach((cube: Cube) => {
         if (cube.color === "empty") {
             c++;
         }
@@ -190,7 +190,7 @@ function helpFunct(tempContainer, queue, path = []): boolean {
     return false;
 }
 
-function cubesUpdate(tempContainer, connectedCubes) {
+function cubesUpdate(tempContainer: Cube[], connectedCubes: Set<Cube>): [Cube[], number] {
     let possibleClicks: number = -1;
     connectedCubes.forEach(cube => {
         const idx = tempContainer.indexOf(cube);
@@ -234,8 +234,8 @@ function cubesUpdate(tempContainer, connectedCubes) {
     return [tempContainer, possibleClicks];
 }
 
-function updateQueue(tempContainer): Set<unknown>[] {
-    let queue: Set<unknown>[] = [];
+function updateQueue(tempContainer: Cube[]): Set<Cube>[] {
+    let queue: Set<Cube>[] = [];
     let visited = new Set();
 
     tempContainer.forEach(cube => {
@@ -292,8 +292,8 @@ function shouldFail(): boolean {
     return true;
 }
 
-function getConnectedCubes(tempContainer, cube) {
-    const connectedCubes = new Set();
+function getConnectedCubes(tempContainer: Cube[], cube: Cube): Set<Cube> {
+    const connectedCubes: Set<Cube> = new Set();
     const queue = [cube];
 
     while (queue.length > 0) {
@@ -314,7 +314,7 @@ function getConnectedCubes(tempContainer, cube) {
     return connectedCubes;
 }
 
-function getAdjacentCubes(tempContainer, cube) {
+function getAdjacentCubes(tempContainer: Cube[], cube: Cube) {
     const idx = tempContainer.indexOf(cube);
     const adjacentCubes: Cube[] = [];
 
@@ -329,10 +329,10 @@ function getAdjacentCubes(tempContainer, cube) {
     return adjacentCubes;      
 }
 
-function getColorCount(tempContainer): number[] {
+function getColorCount(tempContainer: Cube[]): number[] {
     const colorCount = [0, 0, 0];
 
-    tempContainer.forEach(cube => {
+    tempContainer.forEach((cube: Cube) => {
         if (cube.color == "red") {
             colorCount[0]++;
         } else if (cube.color == "green") {


### PR DESCRIPTION
> [!IMPORTANT]  
> #33 Must be merged before this PR. The changes here rely on the restructure made in that PR.

This PR updates the roof running puzzle blocks to use the same colors as the NoPixel version. I used an eyedropper tool to grab the precise colors, and applied a linear gradient to each block.

Specifically, I restructured the HTML for each block.
Old:
 ```html
<div class="cube cubeg"></div>
```
New:
```html
<div class="cubeg">
  <div class="cube"></div>
</div>
```
This was necessary in order to utilize the background CSS attribute, since `linear-gradient()` is considered an image instead of a color. The `.cube` CSS style sets the `background-size` attribute, which would also affect the gradient background. Instead, I just made a second div as a child, and left the existing CSS as-is.